### PR TITLE
Make ZioHttpResponseBody public

### DIFF
--- a/server/zio-http-server/src/main/scala/sttp/tapir/server/ziohttp/ZioHttpResponseBody.scala
+++ b/server/zio-http-server/src/main/scala/sttp/tapir/server/ziohttp/ZioHttpResponseBody.scala
@@ -3,11 +3,11 @@ package sttp.tapir.server.ziohttp
 import zio.stream.ZStream
 import zio.Chunk
 
-private[ziohttp] sealed trait ZioHttpResponseBody {
+sealed trait ZioHttpResponseBody {
   def contentLength: Option[Long]
 }
 
-private[ziohttp] case class ZioStreamHttpResponseBody(stream: ZStream[Any, Throwable, Byte], contentLength: Option[Long])
+case class ZioStreamHttpResponseBody(stream: ZStream[Any, Throwable, Byte], contentLength: Option[Long])
     extends ZioHttpResponseBody
 
-private[ziohttp] case class ZioRawHttpResponseBody(bytes: Chunk[Byte], contentLength: Option[Long]) extends ZioHttpResponseBody
+case class ZioRawHttpResponseBody(bytes: Chunk[Byte], contentLength: Option[Long]) extends ZioHttpResponseBody


### PR DESCRIPTION
Small change that will make it possible to eg. log server response body using Tapir interceptor. Right now it cannot be done without using some hacks as `ZioRawHttpResponseBody` trait (and case classes that extend this trait) are marked as private.